### PR TITLE
Allow disabling route controller if Route Table ID is not provided

### DIFF
--- a/pkg/cloudprovider/yandex/cloud.go
+++ b/pkg/cloudprovider/yandex/cloud.go
@@ -237,6 +237,10 @@ func (yc *Cloud) Clusters() (cloudprovider.Clusters, bool) {
 
 // Routes returns a routes interface if supported
 func (yc *Cloud) Routes() (cloudprovider.Routes, bool) {
+	if len(yc.config.RouteTableID) == 0 {
+		return nil, false
+	}
+
 	return yc, true
 }
 

--- a/pkg/cloudprovider/yandex/cloud.go
+++ b/pkg/cloudprovider/yandex/cloud.go
@@ -133,9 +133,6 @@ func NewCloudConfig() (*CloudConfig, error) {
 	}
 
 	cloudConfig.RouteTableID = os.Getenv(envRouteTableID)
-	if len(cloudConfig.RouteTableID) == 0 {
-		log.Fatalf("%q env is required", envRouteTableID)
-	}
 
 	cloudConfig.lbListenerSubnetID = os.Getenv(envLbListenerSubnetID)
 


### PR DESCRIPTION
Hello. We don't use route tables in yandex clound and want to remove this check from cloudprovider.